### PR TITLE
Improve Index Editor handling

### DIFF
--- a/site/js/index.mjs
+++ b/site/js/index.mjs
@@ -334,8 +334,6 @@ function dropSearchElement(evt) {
         return;
     }
 
-    Logger.debug("drop search element");
-
     const targetParent = evt.target.parentNode;
     const type = targetParent.dataset.qtype;
     

--- a/site/js/models/DqlFilter.mjs
+++ b/site/js/models/DqlFilter.mjs
@@ -145,7 +145,7 @@ function buildFilter(queryObj, refType) {
         const tf = buildMatchTermFilter(queryObj);
 
         if (tf && tf.length){
-             aFilter.push();
+             aFilter.push(tf);
         }
     }
     else {
@@ -306,7 +306,7 @@ function matchSelector(filter, options) {
         forbidden_context: SdgMatch.forbidden_context
         language: SdgMatch.language
         sdg: SdgMatch.sdg {
-    			id: Sdg.id
+			id: Sdg.id
         }
     }`;
 }

--- a/site/js/models/Indexer.mjs
+++ b/site/js/models/Indexer.mjs
@@ -34,13 +34,11 @@ export function getRecords() {
 export function getOneRecord(id) {
     if (Model.records[id]) {
         const query = Model.records[id].qterms
-            .filter(t => t.type !== "sdg")
             .map(t => Object.assign({}, t));
         
         Events.trigger.queryReplace(query);
     }
 }
-
 
 /**
  * filter records for a specific language and/or SDG
@@ -189,7 +187,7 @@ async function mutateData(query, variables) {
 }
 
 async function loadData() {
-    const data = await Filter.indexQuery(QueryModel.query(), 100, 0, RequestController);
+    const data = await Filter.indexQuery(QueryModel.query(true), 100, 0, RequestController);
 
     if (data && "sdgmatch" in data) {
         Model.data = data.sdgmatch.map(parseRecord);

--- a/site/js/models/Query.mjs
+++ b/site/js/models/Query.mjs
@@ -2,14 +2,19 @@ import * as Config from "./Config.mjs";
 import * as Logger from "../Logger.mjs";
 import * as Events from "../Events.mjs";
 
+import * as IdxView from "../views/indexterms.mjs";
 
 Events.listen.queryAddItem(add);
 Events.listen.queryClear(clear);
 Events.listen.queryDrop(drop);
 Events.listen.queryReplace(replaceQuery);
 
-export function query() {
+export function query(force) {
     const query = collectQueryTerms(QueryModel.qterms);
+
+    if (!force && IdxView.isActive()) {
+        delete query.sdgs;
+    }
 
     Logger.debug(`queryModel: ${JSON.stringify(query)}`)
     

--- a/site/js/models/Query.mjs
+++ b/site/js/models/Query.mjs
@@ -197,9 +197,9 @@ function add(ev) {
 
 function drop(ev) {
     const type = ev.detail.type;
-    const value = ev.detail.value;
+    const value = ev.detail.value.toString();
 
-    QueryModel.qterms = QueryModel.qterms.filter(t => !(type === t.type && value === t.value));
+    QueryModel.qterms = QueryModel.qterms.filter(t => !(type === t.type && value === t.value.toString()));
 
     Events.trigger.queryUpdate();
 

--- a/site/js/views/indexterms.mjs
+++ b/site/js/views/indexterms.mjs
@@ -10,6 +10,16 @@ export function init(target) {
     target.addEventListener("click", handleIndexDelete);
 }
 
+export function isActive() {
+    const menuitem = document.querySelector(".active #indexmatcher_menu");
+
+    if (menuitem) {
+        return true;
+    }
+
+    return false;
+}
+
 function handleIndexActivate(ev) {
     if (!ev.target.parentNode.classList.contains("indexterm") || ev.target.classList.contains("disabled")) {
         return;
@@ -36,8 +46,8 @@ function renderIndexTerms() {
     
     Logger.debug("render index terms");
 
-    const menuitem = document.querySelector("#indexmatcher_menu");
-    if(!menuitem.parentNode.classList.contains("active")) {
+    const menuitem = document.querySelector(".active #indexmatcher_menu");
+    if(!menuitem) {
         return; 
     }    
 


### PR DESCRIPTION
fixes #68 

- The index editor should expose the entire query.
- If the index editor is active, then the results and the statistics should not use any SDG for filtering. 

The improvements allows to add/edit/remove SDG terms, without removing the the SDG itself.
