### PR TITLE
Moved query error tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ For testing and development the package brings a minimal backend deployment. Thi
 
 Testing requires that [nodejs (with npm)](https://nodejs.org) and [docker](https://docker.com) are installed on the system. 
 
-On the command line runn the following commands
+On the command line run the following commands
 
 ```sh
 npm ci 
 npm run all
-docker compose -f docker-compose-integration.yaml up --force-recreate --remove-orphans
+docker compose -f docker-compose-local.yaml up --force-recreate --remove-orphans
 ```
 
 The setup takes about 30-40 seconds to fully start, because of database initialisation. After that it takes a few hours for scraping the OAI endpoint. During that time one can be amazed by observing how the data tickles into the system. 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On the command line run the following commands
 ```sh
 npm ci 
 npm run all
-docker compose -f docker-compose-local.yaml up --force-recreate --remove-orphans
+docker compose -f docker-compose-integration.yaml up --force-recreate --remove-orphans
 ```
 
 The setup takes about 30-40 seconds to fully start, because of database initialisation. After that it takes a few hours for scraping the OAI endpoint. During that time one can be amazed by observing how the data tickles into the system. 

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -273,18 +273,37 @@
         .input-group-text {
             color: var(--bs-gray-600);
             cursor: pointer;
+
+            display: inline-block;
+            z-index: 0;
+
+            grid-area: inputbuttons;
         }
 
         form {
             margin-block-end: 0;
         }
 
-        // Depends on its parent (div .input-group) to be positioned relatively!
+        .input-group {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            grid-template-areas: "searchinput inputbuttons";
+        }
+
         #query-warning {
-            position: absolute;
-            right: 0;
-            height: 100%;
-            z-index: 9;
+            display: none;
+        }
+
+        #query-warning.error {
+            @extend .btn;
+            @extend .btn-danger;
+
+            display: inline-block;
+            grid-area: inputbuttons;
+        }
+
+        .form-control {
+            width: 100%;
         }
     }
 

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -290,10 +290,6 @@
             grid-template-areas: "searchinput inputbuttons";
         }
 
-        #query-warning {
-            display: none;
-        }
-
         #query-warning.error {
             @extend .btn;
             @extend .btn-danger;

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -270,11 +270,6 @@
             box-shadow: none;
         }
 
-        .form-control.error {
-            background-color: tint-color($danger, 60%);
-            color: black;
-        }
-
         .input-group-text {
             color: var(--bs-gray-600);
             cursor: pointer;
@@ -282,6 +277,14 @@
 
         form {
             margin-block-end: 0;
+        }
+
+        // Depends on its parent (div .input-group) to be positioned relatively!
+        #query-warning {
+            position: absolute;
+            right: 0;
+            height: 100%;
+            z-index: 9;
         }
     }
 
@@ -355,12 +358,44 @@
                 }
             }
 
-            // If the the user enters a search term twice, mark it in the $danger (error) color.
-            // The :not() operator is used to exclude the SDG markers (which have their own distinct color that
-            // we don't want to override.
-            .error > *:not(.marker) {
-                background-color: tint-color($danger, 60%) !important;
-                color: black;
+            .error > * {
+                $shadow-danger-color: tint-color($danger, 20%);
+                $shadow-size: 2px;
+
+                // We need to use box-shadow since css borders count as part of the object and increase their
+                // size. This would increase the height of the second parent and cause a weird jump.
+                // Also we can't simply add the border on the first parent, since the children that are being
+                // targeted overflow it for some reason.
+                &:nth-child(1) {
+                    box-shadow:
+                    // Top
+                    0 (-$shadow-size) 0 $shadow-danger-color,
+                    // Left
+                    (-$shadow-size) 0 0 $shadow-danger-color,
+                    // Bottom
+                    0 $shadow-size 0 $shadow-danger-color,
+                    // Gap in top-left corner
+                    (-$shadow-size) (-$shadow-size) 0 $shadow-danger-color,
+                    // Gap in bottom-left corner
+                    (-$shadow-size) $shadow-size 0 $shadow-danger-color;
+                }
+
+                &:nth-child(2) {
+                    box-shadow:
+                    // Top
+                    0 (-$shadow-size) 0 $shadow-danger-color,
+                    // Right
+                    $shadow-size 0 0 $shadow-danger-color,
+                    // Bottom
+                    0 $shadow-size 0 $shadow-danger-color,
+                    // Gap in top-right corner
+                    $shadow-size (-$shadow-size) 0 $shadow-danger-color,
+                    // Gap in bottom-right corner
+                    $shadow-size $shadow-size 0 $shadow-danger-color;
+
+                    border-top-right-radius: .5em;
+                    border-bottom-right-radius: .5em;
+                }
             }
         }
 

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -354,6 +354,14 @@
                     }
                 }
             }
+
+            // If the the user enters a search term twice, mark it in the $danger (error) color.
+            // The :not() operator is used to exclude the SDG markers (which have their own distinct color that
+            // we don't want to override.
+            .error > *:not(.marker) {
+                background-color: tint-color($danger, 60%) !important;
+                color: black;
+            }
         }
 
         .searchtools {

--- a/site/index.html
+++ b/site/index.html
@@ -79,7 +79,7 @@
                         <span class="input-group-text" id="basic-addon2">Press Return to add</span>
 
                         <!-- Content is overwritten by showQueryError() function  -->
-                        <span id="query-warning">The query exists already</span>
+                        <span id="query-warning" hidden>The query exists already</span>
                     </div>
                 </form>
             </div>

--- a/site/index.html
+++ b/site/index.html
@@ -77,6 +77,10 @@
                     <div class="input-group">
                         <input type="text" class="form-control" id="searchterms">
                         <span class="input-group-text" id="basic-addon2">Press Return to add</span>
+
+                        <!-- Positioned absolutely, content is overwritten by showQueryError() function  -->
+                        <span class="text-bg-danger px-3 d-none d-flex align-items-center rounded-2 error"
+                              id="query-warning">The query exists already</span>
                     </div>
                 </form>
             </div>

--- a/site/index.html
+++ b/site/index.html
@@ -78,9 +78,8 @@
                         <input type="text" class="form-control" id="searchterms">
                         <span class="input-group-text" id="basic-addon2">Press Return to add</span>
 
-                        <!-- Positioned absolutely, content is overwritten by showQueryError() function  -->
-                        <span class="text-bg-danger px-3 d-none d-flex align-items-center rounded-2 error"
-                              id="query-warning">The query exists already</span>
+                        <!-- Content is overwritten by showQueryError() function  -->
+                        <span id="query-warning">The query exists already</span>
                     </div>
                 </form>
             </div>

--- a/site/js/index.mjs
+++ b/site/js/index.mjs
@@ -206,12 +206,9 @@ function showQueryError(ev) {
     searchTermElement.classList.add("error");
 
     // Mark the search term that caused the error with the error color.
-    for (const offendingTerm of ev.detail.offendingSearchTerms) {
-        const selectedOptions = document.querySelectorAll(`.optioncontainer[data-qvalue="${offendingTerm.value}"]`);
-        if (selectedOptions.length > 0) {
-            selectedOptions[0].classList.add("error");
-        }
-    }
+    ev.detail.offendingSearchTerms.forEach(({value}) => {
+        document.querySelector(`.optioncontainer[data-qvalue="${value}"]`)?.classList.add("error");
+    });
 
     // tell the user that something is missing
     const tooltip = bootstrap.Tooltip.getOrCreateInstance(searchButtonElement, {
@@ -231,9 +228,9 @@ function clearQueryError() {
 
     searchTermElement.classList.remove("error");
 
-    for (let option of document.querySelectorAll(`.optioncontainer.error`)) {
-        option.classList.remove('error');
-    }
+    document.querySelectorAll(".optioncontainer.error").forEach((optionElement) =>  {
+        optionElement.classList.remove("error");
+    });
 
     // tell the user that something is missing
     const ttip = bootstrap.Tooltip.getInstance(searchButtonElement);

--- a/site/js/index.mjs
+++ b/site/js/index.mjs
@@ -201,9 +201,9 @@ function addQType(evt) {
 
 function showQueryError(ev) {
     // tell the user that something is missing
-    const queryWarningElement = document.getElementById("query-warning")
+    const queryWarningElement = document.querySelector("#query-warning");
 
-    queryWarningElement.classList.remove("d-none");
+    queryWarningElement.classList.add("error");
     queryWarningElement.innerText = ev.detail.message;
 
     // Adds red border around the search term box
@@ -215,7 +215,7 @@ function showQueryError(ev) {
 function clearQueryError() {
     const queryWarningElement = document.querySelector("#query-warning");
 
-    queryWarningElement.classList.add("d-none");
+    queryWarningElement.classList.remove("error");
 
     document.querySelectorAll(".optioncontainer.error").forEach((optionElement) =>  {
         optionElement.classList.remove("error");

--- a/site/js/index.mjs
+++ b/site/js/index.mjs
@@ -205,6 +205,7 @@ function showQueryError(ev) {
 
     queryWarningElement.classList.add("error");
     queryWarningElement.innerText = ev.detail.message;
+    queryWarningElement.removeAttribute("hidden");
 
     // Adds red border around the search term box
     ev.detail.offendingSearchTerms.forEach(({value}) => {
@@ -216,6 +217,7 @@ function clearQueryError() {
     const queryWarningElement = document.querySelector("#query-warning");
 
     queryWarningElement.classList.remove("error");
+    queryWarningElement.setAttribute("hidden", "hidden");
 
     document.querySelectorAll(".optioncontainer.error").forEach((optionElement) =>  {
         optionElement.classList.remove("error");

--- a/site/js/index.mjs
+++ b/site/js/index.mjs
@@ -201,16 +201,25 @@ function addQType(evt) {
 
 function showQueryError(ev) {
     const searchTermElement = document.querySelector("#searchterms");
-    
-    searchTermElement.classList.add("error");            
-            
+    const searchButtonElement = document.querySelector("#basic-addon2");
+
+    searchTermElement.classList.add("error");
+
+    // Mark the search term that caused the error with the error color.
+    for (const offendingTerm of ev.detail.offendingSearchTerms) {
+        const selectedOptions = document.querySelectorAll(`.optioncontainer[data-qvalue="${offendingTerm.value}"]`);
+        if (selectedOptions.length > 0) {
+            selectedOptions[0].classList.add("error");
+        }
+    }
+
     // tell the user that something is missing
-    const tooltip = bootstrap.Tooltip.getOrCreateInstance(searchTermElement, {
-       title: ev.detail.message,
-       placement: "bottom",
-       popperConfig: {
-            placement: "bottom-start",                 
-       }
+    const tooltip = bootstrap.Tooltip.getOrCreateInstance(searchButtonElement, {
+        title: ev.detail.message,
+        placement: "left",
+        popperConfig: {
+            placement: "left",
+        }
     });
 
     tooltip.show();
@@ -218,11 +227,16 @@ function showQueryError(ev) {
 
 function clearQueryError() {
     const searchTermElement = document.querySelector("#searchterms");
-    
-    searchTermElement.classList.remove("error");            
-            
+    const searchButtonElement = document.querySelector("#basic-addon2");
+
+    searchTermElement.classList.remove("error");
+
+    for (let option of document.querySelectorAll(`.optioncontainer.error`)) {
+        option.classList.remove('error');
+    }
+
     // tell the user that something is missing
-    const ttip = bootstrap.Tooltip.getInstance(searchTermElement);
+    const ttip = bootstrap.Tooltip.getInstance(searchButtonElement);
     if (ttip) {
         ttip.dispose();
     }

--- a/site/js/index.mjs
+++ b/site/js/index.mjs
@@ -200,43 +200,26 @@ function addQType(evt) {
 // search query functions 
 
 function showQueryError(ev) {
-    const searchTermElement = document.querySelector("#searchterms");
-    const searchButtonElement = document.querySelector("#basic-addon2");
+    // tell the user that something is missing
+    const queryWarningElement = document.getElementById("query-warning")
 
-    searchTermElement.classList.add("error");
+    queryWarningElement.classList.remove("d-none");
+    queryWarningElement.innerText = ev.detail.message;
 
-    // Mark the search term that caused the error with the error color.
+    // Adds red border around the search term box
     ev.detail.offendingSearchTerms.forEach(({value}) => {
         document.querySelector(`.optioncontainer[data-qvalue="${value}"]`)?.classList.add("error");
     });
-
-    // tell the user that something is missing
-    const tooltip = bootstrap.Tooltip.getOrCreateInstance(searchButtonElement, {
-        title: ev.detail.message,
-        placement: "left",
-        popperConfig: {
-            placement: "left",
-        }
-    });
-
-    tooltip.show();
 }
 
 function clearQueryError() {
-    const searchTermElement = document.querySelector("#searchterms");
-    const searchButtonElement = document.querySelector("#basic-addon2");
+    const queryWarningElement = document.querySelector("#query-warning");
 
-    searchTermElement.classList.remove("error");
+    queryWarningElement.classList.add("d-none");
 
     document.querySelectorAll(".optioncontainer.error").forEach((optionElement) =>  {
         optionElement.classList.remove("error");
     });
-
-    // tell the user that something is missing
-    const ttip = bootstrap.Tooltip.getInstance(searchButtonElement);
-    if (ttip) {
-        ttip.dispose();
-    }
 }
 
 // Self registering UI Events

--- a/site/js/models/Query.mjs
+++ b/site/js/models/Query.mjs
@@ -206,9 +206,13 @@ function add(ev) {
         return;
     }
 
-    if (QueryModel.qterms.filter(obj => obj.type === type && obj.value === value).length) {
+    const offendingSearchTerms = QueryModel.qterms.filter(obj => obj.type === type && obj.value === value);
+    if (offendingSearchTerms.length > 0) {
         Logger.debug("item exists");
-        Events.trigger.queryError({message: "The query already exists."});
+        Events.trigger.queryError({
+            message: "The query already exists.",
+            offendingSearchTerms: offendingSearchTerms,
+        });
         return;
     }
 

--- a/site/js/models/Query.mjs
+++ b/site/js/models/Query.mjs
@@ -207,6 +207,7 @@ function add(ev) {
     }
 
     const offendingSearchTerms = QueryModel.qterms.filter(obj => obj.type === type && obj.value === value);
+
     if (offendingSearchTerms.length > 0) {
         Logger.debug("item exists");
         Events.trigger.queryError({


### PR DESCRIPTION
@phish108 
Here's my suggestion on how to address #58. Please tell me whether this is to your expectation. 

When entering a search term twice:
![image](https://user-images.githubusercontent.com/39983753/220691022-50144bf1-89b0-4663-bea0-cf98048ca8a1.png)

When selecting an SDG twice: 
![image](https://user-images.githubusercontent.com/39983753/220692082-e703d6fc-cd3a-46ba-a542-46bf8309853f.png)

**Description**
Moved error tooltip "The query already exists." to no longer block the existing search terms and mark the offending search term in red color.

- The error tooltip is now positioned to the left of the search button ("Press Return to add")
- Added styles for "optioncontainer" class to be able to have the error class which marks its children with a red background color. This currently happens when adding a search term that was added already.

Closes #58 